### PR TITLE
Fix a chown command wrong information

### DIFF
--- a/lessons/users-groups-and-permissions.md
+++ b/lessons/users-groups-and-permissions.md
@@ -111,7 +111,7 @@ mkdir hello # permission denied, you don't have permission to do that here
 sudo mkdir hello # works, but now hello is owned by root:root
 ls -l # notice hello is owned by root:root
 touch hello/text.txt # permission denied, you don't own hello
-sudo chown ubuntu:ubuntu hello # it's <group>:<user>
+sudo chown ubuntu:ubuntu hello # it's <user>:<group>
 ls -l # notice hello is now owned by ubuntu:ubuntu
 touch hello/text.txt # works!
 ```


### PR DESCRIPTION
In the command
`sudo chown ubuntu:ubuntu hello # it's <group>:<user>` but it should be `<user>:<group>`.
It is fixed in my commit. 